### PR TITLE
Add `TapSelectionHandler` for handling taps and ignoring selection

### DIFF
--- a/Sources/Composed/Handlers/TapSelectionHandler.swift
+++ b/Sources/Composed/Handlers/TapSelectionHandler.swift
@@ -1,0 +1,17 @@
+/// A type that handles taps on individual elements.
+///
+/// When conforming to this protocol do not implement any of the methods from ``SelectionHandler``;
+/// only implement ``didTapElement(at:)`` and handle the tap there.
+public protocol TapSelectionHandler: SelectionHandler {
+    /// A function called when the view representing the element at `index`.
+    ///
+    /// - parameter index: The index of the view that was tapped.
+    func didTapElement(at index: Int)
+}
+
+extension TapSelectionHandler {
+    public func shouldSelect(at index: Int) -> Bool {
+        didTapElement(at: index)
+        return false
+    }
+}

--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -769,7 +769,11 @@ extension CollectionCoordinator: UICollectionViewDelegate {
             return originalDelegate?.collectionView?(collectionView, shouldSelectItemAt: indexPath) ?? false
         }
 
-        return handler.shouldSelect(at: indexPath.item)
+        if let handler = handler as? CollectionSelectionHandler, let cell = collectionView.cellForItem(at: indexPath) {
+            return handler.shouldSelect(at: indexPath.item, cell: cell)
+        } else {
+            return handler.shouldSelect(at: indexPath.item)
+        }
     }
 
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Sources/ComposedUI/CollectionView/FlatUICollectionViewSection.swift
+++ b/Sources/ComposedUI/CollectionView/FlatUICollectionViewSection.swift
@@ -29,8 +29,27 @@ open class FlatUICollectionViewSection: FlatSection, UICollectionViewSection {
 }
 
 extension FlatUICollectionViewSection: CollectionSelectionHandler {
+    public func shouldSelect(at index: Int, cell: UICollectionViewCell) -> Bool {
+        guard let sectionMeta = self.sectionForElementIndex(index) else {
+            return shouldSelect(at: index)
+        }
+
+        let sectionIndex = index - sectionMeta.offset
+
+        if let section = sectionMeta.section as? CollectionSelectionHandler {
+            return section.shouldSelect(at: sectionIndex, cell: cell)
+        } else if let section = sectionMeta.section as? SelectionHandler {
+            return section.shouldSelect(at: sectionIndex)
+        } else {
+            return shouldSelect(at: index)
+        }
+    }
+
     public func didSelect(at index: Int, cell: UICollectionViewCell) {
-        guard let sectionMeta = self.sectionForElementIndex(index) else { return }
+        guard let sectionMeta = self.sectionForElementIndex(index) else {
+            didSelect(at: index)
+            return
+        }
 
         let sectionIndex = index - sectionMeta.offset
 
@@ -38,11 +57,16 @@ extension FlatUICollectionViewSection: CollectionSelectionHandler {
             section.didSelect(at: sectionIndex, cell: cell)
         } else if let section = sectionMeta.section as? SelectionHandler {
             section.didSelect(at: sectionIndex)
+        } else {
+            didSelect(at: index)
         }
     }
 
     public func didDeselect(at index: Int, cell: UICollectionViewCell) {
-        guard let sectionMeta = self.sectionForElementIndex(index) else { return }
+        guard let sectionMeta = self.sectionForElementIndex(index) else {
+            didDeselect(at: index)
+            return
+        }
 
         let sectionIndex = index - sectionMeta.offset
 
@@ -50,6 +74,8 @@ extension FlatUICollectionViewSection: CollectionSelectionHandler {
             section.didDeselect(at: sectionIndex, cell: cell)
         } else if let section = sectionMeta.section as? SelectionHandler {
             section.didDeselect(at: sectionIndex)
+        } else {
+            didDeselect(at: index)
         }
     }
 }

--- a/Sources/ComposedUI/CollectionView/Handlers/CollectionSelectionHandler.swift
+++ b/Sources/ComposedUI/CollectionView/Handlers/CollectionSelectionHandler.swift
@@ -4,6 +4,12 @@ import Composed
 /// Provides selection handling for `UICollectionView`'s
 @MainActor
 public protocol CollectionSelectionHandler: SelectionHandler, UICollectionViewSection {
+    /// A function called when the user tries to select a cell by tapping it.
+    ///
+    /// - parameter cell: The cell that was tapped.
+    /// - parameter index: The index of the tapped cell.
+    /// - returns: `true` if the cell should be selected, otherwise `false`.
+    func shouldSelectCell(_ cell: UICollectionViewCell, at index: Int) -> Bool
 
     /// When a selection occurs, this method will be called to notify the section
     /// - Parameters:
@@ -20,6 +26,10 @@ public protocol CollectionSelectionHandler: SelectionHandler, UICollectionViewSe
 }
 
 public extension CollectionSelectionHandler {
+    func shouldSelect(at index: Int, cell: UICollectionViewCell) -> Bool {
+        shouldSelect(at: index)
+    }
+
     func didSelect(at index: Int, cell: UICollectionViewCell) {
         didSelect(at: index)
     }

--- a/Sources/ComposedUI/CollectionView/Handlers/CollectionTapSelectionHandler.swift
+++ b/Sources/ComposedUI/CollectionView/Handlers/CollectionTapSelectionHandler.swift
@@ -1,0 +1,22 @@
+import Composed
+import UIKit
+
+/// A type that handles taps on individual cells.
+///
+/// When conforming to this protocol do not implement any of the methods from
+/// ``CollectionSelectionHandler``; only implement ``didTapElement(at:cell:)`` or
+/// `didTapElement(at:)` and handle the tap there.
+public protocol CollectionTapSelectionHandler: CollectionSelectionHandler, TapSelectionHandler {
+    /// A function called when the user taps a cell.
+    ///
+    /// - parameter cell: The cell that was tapped.
+    /// - parameter index: The index of the cell that was tapped.
+    func didTapCell(_ cell: UICollectionViewCell, at index: Int)
+}
+
+extension CollectionTapSelectionHandler {
+    public func shouldSelectCell(_ cell: UICollectionViewCell, at index: Int) -> Bool {
+        didTapCell(cell, at: index)
+        return false
+    }
+}


### PR DESCRIPTION
I'm hoping this is a clearer API compared to using `SelectionHandler.shouldSelect(at:)` or `SelectionHandler.didSelect(at:)`.