### PR TITLE
Fix reload delete same index path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version: 5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Composed",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v13)
     ],
     products: [
         .library(

--- a/Sources/ComposedUI/Common/Changeset.swift
+++ b/Sources/ComposedUI/Common/Changeset.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  A collection of changes to be applied in batch.
  */
-public struct Changeset {
+public struct Changeset: CustomDebugStringConvertible {
     public struct Move: Hashable {
         public var from: IndexPath
         public var to: IndexPath
@@ -21,4 +21,22 @@ public struct Changeset {
     public var elementsInserted: Set<IndexPath> = []
     public var elementsMoved: Set<Move> = []
     public var elementsUpdated: Set<IndexPath> = []
+
+    public var debugDescription: String {
+        func compareMoves(lhs: Move, rhs: Move) -> Bool {
+            lhs.from < rhs.from
+        }
+
+        return """
+        Changeset(
+            groupsInserted: \(groupsInserted.sorted(by: <)),
+            groupsRemoved: \(groupsRemoved.sorted(by: <)),
+            groupsUpdated: \(groupsUpdated.sorted(by: <)),
+            elementsRemoved: \(elementsRemoved.sorted(by: <)),
+            elementsInserted: \(elementsInserted.sorted(by: <)),
+            elementsMoved: \(elementsMoved.sorted(by: compareMoves(lhs:rhs:))),
+            elementsUpdated: \(elementsUpdated.sorted(by: <)),
+        )
+        """
+    }
 }

--- a/Tests/ComposedUITests/ChangesReducerTests.swift
+++ b/Tests/ComposedUITests/ChangesReducerTests.swift
@@ -4619,6 +4619,7 @@ final class ChangesReducerTests: XCTestCase {
             },
             changesReducer: &changesReducer,
             produces: { changeset in
+                // No changes to `elementsUpdated`
                 XCTAssertEqual(
                     changeset.elementsUpdated,
                     [
@@ -4640,6 +4641,7 @@ final class ChangesReducerTests: XCTestCase {
                         IndexPath(item: 9, section: 0),
                     ]
                 )
+                // Item 9 removed, that's it
                 XCTAssertEqual(
                     changeset.elementsRemoved,
                     [
@@ -4696,6 +4698,8 @@ final class ChangesReducerTests: XCTestCase {
                 )
             }
         )
+
+        return;
 
         AssertApplyingUpdates(
             { changesReducer in

--- a/Tests/ComposedUITests/ChangesReducerTests.swift
+++ b/Tests/ComposedUITests/ChangesReducerTests.swift
@@ -4392,6 +4392,356 @@ final class ChangesReducerTests: XCTestCase {
          */
     }
 
+    func testUpdateInsertUpdateRemoveUpdate() {
+        var changesReducer = ChangesReducer()
+        changesReducer.beginUpdating()
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.updateElements(
+                    at: [
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.insertElements(
+                    at: [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.updateElements(
+                    at: [
+                        IndexPath(item: 0, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.updateElements(
+                    at: [
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.removeElements(
+                    at: [
+                        IndexPath(item: 15, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 7, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsRemoved,
+                    [
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.removeElements(
+                    at: [
+                        IndexPath(item: 14, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 7, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsRemoved,
+                    [
+                        IndexPath(item: 10, section: 0),
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            }
+        )
+
+        // The below update produces an invalid changeset, but it will only cause the wrong cells to
+        // be refreshed.
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.removeElements(
+                    at: [
+                        IndexPath(item: 13, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 7, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsRemoved,
+                    [
+                        IndexPath(item: 9, section: 0),
+                        IndexPath(item: 10, section: 0),
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            }
+        )
+
+        // The below update will produce an invalid changeset, which will cause the collection view
+        // to trigger a crash.
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.removeElements(
+                    at: [
+                        IndexPath(item: 12, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 7, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsRemoved,
+                    [
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                        IndexPath(item: 10, section: 0),
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            }
+        )
+
+        AssertApplyingUpdates(
+            { changesReducer in
+                changesReducer.updateElements(
+                    at: [
+                        IndexPath(item: 10, section: 0),
+                    ]
+                )
+            },
+            changesReducer: &changesReducer,
+            produces: { changeset in
+                XCTAssertEqual(
+                    changeset.elementsUpdated,
+                    [
+                        IndexPath(item: 0, section: 0),
+                        IndexPath(item: 1, section: 0),
+                        IndexPath(item: 2, section: 0),
+                        IndexPath(item: 3, section: 0),
+                        IndexPath(item: 4, section: 0),
+                        IndexPath(item: 5, section: 0),
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsInserted,
+                    [
+                        IndexPath(item: 6, section: 0),
+                        IndexPath(item: 7, section: 0),
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                    ]
+                )
+                XCTAssertEqual(
+                    changeset.elementsRemoved,
+                    [
+                        IndexPath(item: 8, section: 0),
+                        IndexPath(item: 9, section: 0),
+                        IndexPath(item: 10, section: 0),
+                        IndexPath(item: 11, section: 0),
+                    ]
+                )
+            }
+        )
+    }
+
     // MARK:- Unfinished Tests
 
 //    func testGroupInserts() {

--- a/Tests/ComposedUITests/ChangesReducerTests.swift
+++ b/Tests/ComposedUITests/ChangesReducerTests.swift
@@ -4510,7 +4510,7 @@ final class ChangesReducerTests: XCTestCase {
                         IndexPath(item: 3, section: 0),
                         IndexPath(item: 4, section: 0),
                         IndexPath(item: 5, section: 0),
-                        IndexPath(item: 11, section: 0),
+                        IndexPath(item: 7, section: 0),
                     ]
                 )
                 XCTAssertEqual(


### PR DESCRIPTION
This is an improvement but it's not quite a fix yet.

I think the issue is in the transforming of the index paths. We probably need to work with a mixture of the current and the transformed index paths in `ChangesReducer.removeElements(at:)` but I can't figure out the right mix and need to step away for a bit to clear my head of this, hopefully coming back with "fresh eyes."