### PR TITLE
Remove elements provider cache

### DIFF
--- a/Sources/ComposedUI/CollectionView/FlatUICollectionViewSection.swift
+++ b/Sources/ComposedUI/CollectionView/FlatUICollectionViewSection.swift
@@ -15,6 +15,8 @@ open class FlatUICollectionViewSection: FlatSection, UICollectionViewSection {
         }
     }
 
+    private var cachedElementsProvider: (elementsProvider: FlatUICollectionViewSectionElementsProvider, traitCollection: UITraitCollection)?
+
     public init(header: CollectionSupplementaryElement? = nil, footer: CollectionSupplementaryElement? = nil) {
         self.header = header
         self.footer = footer
@@ -23,7 +25,16 @@ open class FlatUICollectionViewSection: FlatSection, UICollectionViewSection {
     }
 
     open func collectionViewElementsProvider(with traitCollection: UITraitCollection) -> UICollectionViewSectionElementsProvider {
-        FlatUICollectionViewSectionElementsProvider(section: self, traitCollection: traitCollection)
+        if let cachedElementsProvider, cachedElementsProvider.traitCollection == traitCollection {
+            return cachedElementsProvider.elementsProvider
+        } else {
+            let elementsProvider = FlatUICollectionViewSectionElementsProvider(
+                section: self,
+                traitCollection: traitCollection
+            )
+            cachedElementsProvider = (elementsProvider, traitCollection)
+            return elementsProvider
+        }
     }
 }
 


### PR DESCRIPTION
This is a relatively small change to remove the elements provider cache from `CollectionCoordinator`.

This _will_ have some performance impact, but I am opening this as a draft because if we find a method of recreating the header bug I would like to test this change.

To actually incorporate this change we should update all the `SingleUICollectionViewSection.section(with:)` implementations to cache what is returned, otherwise the impact may be too large. Since most sections don't actually care about the trait collection we could update `SingleUICollectionViewSection` to require a property (which we then implement using a `lazy private(set) var`) rather than a function and add a separate protocol for varying by trait collection.

We stand to benefit from caching the values returned by `SingleUICollectionViewSection` implementations even without these changes, but for now I am focussed on recreating the header bug.