### PR TITLE
Prepare sections before performing a non-batch update of an item

### DIFF
--- a/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
+++ b/Sources/ComposedUI/CollectionView/CollectionCoordinator.swift
@@ -638,6 +638,8 @@ extension CollectionCoordinator: SectionUpdateDelegate {
         if isPerformingUpdates {
             changesReducer.updateElements(at: [indexPath])
         } else {
+            prepareSections()
+
             guard
                 let section = section as? CollectionUpdateMethodProvider
             else {


### PR DESCRIPTION
Without this we can crash if the cell used at the updated index path has not yet been registered.